### PR TITLE
36 compilation error rust part windows

### DIFF
--- a/native/src-tauri/.cargo/config.toml
+++ b/native/src-tauri/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.'cfg(windows)'.build]
-target-dir = "C:/temp/cargo-target" 

--- a/native/src-tauri/.cargo/config.toml
+++ b/native/src-tauri/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(windows)'.build]
+target-dir = "C:/temp/cargo-target" 

--- a/native/src-tauri/build.rs
+++ b/native/src-tauri/build.rs
@@ -1,3 +1,16 @@
+use std::fs;
+use std::path::Path;
+
 fn main() {
+    // Only create custom target directory on Windows to avoid file locking issues
+    #[cfg(target_os = "windows")]
+    {
+        let target_dir = "C:/temp/cargo-target";
+        if !Path::new(target_dir).exists() {
+            fs::create_dir_all(target_dir).expect("Failed to create target directory");
+        }
+    }
+    
+    // Run Tauri build
     tauri_build::build()
 }

--- a/native/src-tauri/build.rs
+++ b/native/src-tauri/build.rs
@@ -1,14 +1,16 @@
 use std::fs;
 use std::path::Path;
+use std::env;
 
 fn main() {
-    // Only create custom target directory on Windows to avoid file locking issues
+    // Set custom target directory only on Windows to avoid file locking issues
     #[cfg(target_os = "windows")]
     {
         let target_dir = "C:/temp/cargo-target";
         if !Path::new(target_dir).exists() {
             fs::create_dir_all(target_dir).expect("Failed to create target directory");
         }
+        env::set_var("CARGO_TARGET_DIR", target_dir);
     }
     
     // Run Tauri build

--- a/native/src-tauri/src/lib.rs
+++ b/native/src-tauri/src/lib.rs
@@ -3,7 +3,6 @@
 //! This crate wires together all core, tool, and utility modules, and sets up the Tauri runtime, plugins, and command handlers for the application.
 
 use tauri::Manager;
-#[cfg(any(target_os = "macos"))]
 mod commands;
 mod core;
 mod tools;
@@ -13,7 +12,6 @@ use std::sync::{Arc, Mutex};
 use tauri::Listener;
 
 use core::record::{DemonstrationState};
-#[cfg(target_os = "macos")]
 use utils::permissions::{has_ax_perms, has_record_perms, request_ax_perms, request_record_perms};
 
 use crate::commands::general::{greet, list_apps, take_screenshot};
@@ -73,13 +71,9 @@ pub fn setup_builder() -> tauri::Builder<tauri::Wry> {
             stop_recording,
             take_screenshot,
             list_apps,
-            #[cfg(target_os = "macos")]
             has_record_perms,
-            #[cfg(target_os = "macos")]
             request_record_perms,
-            #[cfg(target_os = "macos")]
             has_ax_perms,
-            #[cfg(target_os = "macos")]
             request_ax_perms,
             list_recordings,
             get_recording_file,

--- a/native/src-tauri/src/tools/pipeline.rs
+++ b/native/src-tauri/src/tools/pipeline.rs
@@ -5,7 +5,6 @@
 use crate::tools::ffmpeg::{get_ffmpeg_dir, get_ffprobe_dir};
 use crate::utils::settings::get_custom_app_local_data_dir;
 use log::info;
-#[cfg(unix)]
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::OnceLock;

--- a/native/src-tauri/src/utils/permissions.rs
+++ b/native/src-tauri/src/utils/permissions.rs
@@ -52,3 +52,43 @@ mod macos_permissions {
 
 #[cfg(target_os = "macos")]
 pub use macos_permissions::*;
+
+#[cfg(not(target_os = "macos"))]
+mod windows_permissions {
+    /// Checks if the application has accessibility (AX) permissions.
+    /// On Windows, this is always true as permissions are handled differently.
+    ///
+    /// # Returns
+    /// * `true` on Windows (permissions handled by system)
+    #[tauri::command]
+    pub fn has_ax_perms() -> bool {
+        true
+    }
+
+    /// Prompts the user to grant accessibility (AX) permissions.
+    /// On Windows, this is a no-op as permissions are handled differently.
+    #[tauri::command]
+    pub fn request_ax_perms() {
+        // No-op on Windows
+    }
+
+    /// Checks if the application has screen recording permissions.
+    /// On Windows, this is always true as permissions are handled differently.
+    ///
+    /// # Returns
+    /// * `true` on Windows (permissions handled by system)
+    #[tauri::command]
+    pub fn has_record_perms() -> bool {
+        true
+    }
+
+    /// Prompts the user to grant screen recording permissions.
+    /// On Windows, this is a no-op as permissions are handled differently.
+    #[tauri::command]
+    pub fn request_record_perms() {
+        // No-op on Windows
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub use windows_permissions::*;


### PR DESCRIPTION
Soloved Issue: Fixed Windows file locking issues that prevented Cargo from building due to "The process cannot access the file because it is being used by another process" errors.

Applied changes
native/src-tauri/build.rs (modified)

Purpose: 
- Tells Cargo to use a custom build directory on Windows only
- Automatically creates the target directory if it doesn't exist

Windows-only: 
- Only runs on Windows using #[cfg(target_os = "windows")]

Also, I solved the window permission issue.