### PR TITLE
Add Windows build script and update permissions handling

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "${TEMP}/cargo-target"

--- a/src-tauri/build-windows.bat
+++ b/src-tauri/build-windows.bat
@@ -1,0 +1,15 @@
+@echo off
+REM Set the target directory to temp to avoid file locking issues
+set TEMP_DIR=%TEMP%
+set TARGET_DIR=%TEMP_DIR%\cargo-target
+
+REM Create the directory if it doesn't exist
+if not exist "%TARGET_DIR%" mkdir "%TARGET_DIR%"
+
+REM Set the environment variable
+set CARGO_TARGET_DIR=%TARGET_DIR%
+
+echo Using target directory: %TARGET_DIR%
+
+REM Run cargo with the custom target directory
+cargo run

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    // Run Tauri build
     tauri_build::build()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,6 @@
 //! This crate wires together all core, tool, and utility modules, and sets up the Tauri runtime, plugins, and command handlers for the application.
 
 use tauri::Manager;
-#[cfg(any(target_os = "macos"))]
 mod commands;
 mod core;
 pub mod ipc_server;
@@ -13,7 +12,6 @@ use std::sync::{Arc, Mutex};
 use tauri::Listener;
 
 use core::record::DemonstrationState;
-#[cfg(target_os = "macos")]
 use utils::permissions::{has_ax_perms, has_record_perms, request_ax_perms, request_record_perms};
 
 use crate::commands::general::{greet, list_apps, take_screenshot};
@@ -73,13 +71,9 @@ pub fn setup_builder() -> tauri::Builder<tauri::Wry> {
             stop_recording,
             take_screenshot,
             list_apps,
-            #[cfg(target_os = "macos")]
             has_record_perms,
-            #[cfg(target_os = "macos")]
             request_record_perms,
-            #[cfg(target_os = "macos")]
             has_ax_perms,
-            #[cfg(target_os = "macos")]
             request_ax_perms,
             list_recordings,
             get_recording_file,

--- a/src-tauri/src/tools/pipeline.rs
+++ b/src-tauri/src/tools/pipeline.rs
@@ -5,7 +5,6 @@
 use crate::tools::ffmpeg::{get_ffmpeg_dir, get_ffprobe_dir};
 use crate::utils::settings::get_custom_app_local_data_dir;
 use log::info;
-#[cfg(unix)]
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::OnceLock;

--- a/src-tauri/src/utils/permissions.rs
+++ b/src-tauri/src/utils/permissions.rs
@@ -52,3 +52,43 @@ mod macos_permissions {
 
 #[cfg(target_os = "macos")]
 pub use macos_permissions::*;
+
+#[cfg(not(target_os = "macos"))]
+mod windows_permissions {
+    /// Checks if the application has accessibility (AX) permissions.
+    /// On Windows, this is always true as permissions are handled differently.
+    ///
+    /// # Returns
+    /// * `true` on Windows (permissions handled by system)
+    #[tauri::command]
+    pub fn has_ax_perms() -> bool {
+        true
+    }
+
+    /// Prompts the user to grant accessibility (AX) permissions.
+    /// On Windows, this is a no-op as permissions are handled differently.
+    #[tauri::command]
+    pub fn request_ax_perms() {
+        // No-op on Windows
+    }
+
+    /// Checks if the application has screen recording permissions.
+    /// On Windows, this is always true as permissions are handled differently.
+    ///
+    /// # Returns
+    /// * `true` on Windows (permissions handled by system)
+    #[tauri::command]
+    pub fn has_record_perms() -> bool {
+        true
+    }
+
+    /// Prompts the user to grant screen recording permissions.
+    /// On Windows, this is a no-op as permissions are handled differently.
+    #[tauri::command]
+    pub fn request_record_perms() {
+        // No-op on Windows
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub use windows_permissions::*;


### PR DESCRIPTION
This PR fixes the loss of https://github.com/clones-sol/desktop/pull/39
- Introduced a new `build-windows.bat` script to streamline the build process on Windows by setting a temporary target directory.
- Updated `.cargo/config.toml` to specify the target directory for builds.
- Enhanced `permissions.rs` to include Windows-specific permission handling, providing no-op functions for accessibility and screen recording permissions.
- Minor comment addition in `build.rs` to clarify the build process initiation.