### PR TITLE
Fix macOS Sparkle updater

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 import 'dart:io';
 
 import 'package:clones_desktop/application/agent/agent_launcher.dart';
@@ -247,29 +248,37 @@ class _ClonesAppState extends ConsumerState<ClonesApp>
 
   Future<void> _initializeSparkleUpdater() async {
     try {
+      developer.log('[Sparkle] Initializing Sparkle updater...', name: 'Sparkle');
       final sparkle = SparkleUpdater();
 
       // Determine appcast URL based on environment
       String appcastUrl;
-      if (const String.fromEnvironment('ENVIRONMENT') == 'prod') {
+      const environment = String.fromEnvironment('ENVIRONMENT', defaultValue: 'dev');
+      developer.log('[Sparkle] Environment: $environment', name: 'Sparkle');
+      
+      if (environment == 'prod') {
         appcastUrl = 'https://releases.clones-ai.com/latest/darwin/appcast.xml';
       } else {
-        appcastUrl =
-            'https://releases-test.clones-ai.com/latest/darwin/appcast.xml';
+        appcastUrl = 'https://releases-test.clones-ai.com/latest/darwin/appcast.xml';
       }
+      
+      developer.log('[Sparkle] Using appcast URL: $appcastUrl', name: 'Sparkle');
 
       await sparkle.initialize(
         appcastUrl: appcastUrl,
         automaticallyChecksForUpdates: true,
-        automaticallyDownloadsUpdates: false, // Let user choose
+        automaticallyDownloadsUpdates: false,
       );
+      
+      developer.log('[Sparkle] Sparkle initialized successfully', name: 'Sparkle');
 
       // Check for updates in background
+      developer.log('[Sparkle] Checking for updates in background...', name: 'Sparkle');
       await sparkle.checkForUpdatesInBackground();
+      developer.log('[Sparkle] Background update check completed', name: 'Sparkle');
 
-      debugPrint('Sparkle updater initialized and checking for updates');
     } catch (e) {
-      debugPrint('Failed to initialize Sparkle updater: $e');
+      developer.log('[Sparkle] Failed to initialize Sparkle updater: $e', name: 'Sparkle', level: 1000);
     }
   }
 

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -32,6 +32,8 @@
 	<string>NSApplication</string>
 	<key>SUPublicEDKey</key>
 	<string>wAFtsPUOvfOIZ3FzHgJen1GJEtqXbiIV4RNUW3IgbHo=</string>
+	<key>SUFeedURL</key>
+	<string>$(SPARKLE_FEED_URL)</string>
 	<key>com.apple.security.files.downloads.read-write</key>
 	<true/>
 </dict>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: clones_desktop
 description: "A desktop application for contributing to the world's largest dataset for multimodal computer-use agents."
 publish_to: 'none'
 
-version: 0.2.36+1
+version: 0.2.45+45
 
 environment:
   sdk: ">=3.6.0 <4.0.0"

--- a/scripts/macos/build_flutter_native.sh
+++ b/scripts/macos/build_flutter_native.sh
@@ -302,6 +302,20 @@ build_flutter_macos() {
     local dart_defines=""
     dart_defines+="--dart-define=ENVIRONMENT=${ENVIRONMENT:-dev}"
     
+    # Set Sparkle feed URL based on environment
+    local sparkle_feed_url=""
+    case "${ENVIRONMENT:-dev}" in
+        "prod")
+            sparkle_feed_url="https://releases.clones-ai.com/latest/darwin/appcast.xml"
+            ;;
+        "test")
+            sparkle_feed_url="https://releases-test.clones-ai.com/latest/darwin/appcast.xml"
+            ;;
+        *)
+            sparkle_feed_url="https://releases-${ENVIRONMENT:-dev}.clones-ai.com/latest/darwin/appcast.xml"
+            ;;
+    esac
+    
     # Read environment-specific variables if file exists
     local env_file=".env.${ENVIRONMENT:-dev}"
     if [ -f "$env_file" ]; then
@@ -322,6 +336,7 @@ build_flutter_macos() {
     fi
     
     log_verbose "Building with: $dart_defines"
+    export SPARKLE_FEED_URL="$sparkle_feed_url"
     flutter build macos --release $dart_defines
     
     # Copy the universal build

--- a/scripts/macos/deploy_macos.sh
+++ b/scripts/macos/deploy_macos.sh
@@ -40,6 +40,15 @@ main() {
     
     local environment="$1"
     
+    log_info "Cleaning previous build artifacts..."
+    if ls build_output_* 1> /dev/null 2>&1; then
+        log_info "Removing existing build_output_* directories..."
+        rm -rf build_output_*
+        log_success "Previous builds cleaned"
+    else
+        log_info "No previous builds found"
+    fi
+    
     log_info "Step 1/2: Building release..."
     ENVIRONMENT="$environment" ./scripts/macos/build_release_local.sh
     

--- a/scripts/macos/generate_appcast.sh
+++ b/scripts/macos/generate_appcast.sh
@@ -205,7 +205,23 @@ generate_appcast_from_build() {
     echo "$SPARKLE_PRIVATE_KEY" > "/tmp/sparkle_private.pem"
     
     # Use Sparkle's generate_appcast tool (resolved absolute path)
-    "$GEN_APPCAST" --ed-key-file "/tmp/sparkle_private.pem" --download-url-prefix "https://releases${ENVIRONMENT:+-$ENVIRONMENT}.clones-ai.com/latest/darwin/" "$releases_dir"
+    local download_url_prefix
+    case "$ENVIRONMENT" in
+        "prod")
+            download_url_prefix="https://releases.clones-ai.com/latest/darwin/"
+            ;;
+        "test")
+            download_url_prefix="https://releases-test.clones-ai.com/latest/darwin/"
+            ;;
+        *)
+            download_url_prefix="https://releases-${ENVIRONMENT}.clones-ai.com/latest/darwin/"
+            ;;
+    esac
+    
+    # Clean existing appcast to ensure fresh generation
+    rm -f "${releases_dir}/appcast.xml"
+    
+    "$GEN_APPCAST" --ed-key-file "/tmp/sparkle_private.pem" --download-url-prefix "$download_url_prefix" "$releases_dir"
     
     # Clean up temporary key file
     rm "/tmp/sparkle_private.pem"

--- a/scripts/macos/upload_sparkle_macos.sh
+++ b/scripts/macos/upload_sparkle_macos.sh
@@ -125,7 +125,7 @@ create_tauri_manifest() {
     local version="$1"
     local releases_dir="$2"
     
-    local manifest_file=$(mktemp)
+    local manifest_file=$(mktemp -t "manifest_XXXXXX")
     local upload_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     
     # Find DMG files and extract info
@@ -206,7 +206,7 @@ create_version_manifest() {
     local version="$1"
     local releases_dir="$2"
     
-    local manifest_file=$(mktemp)
+    local manifest_file=$(mktemp -t "manifest_XXXXXX")
     local upload_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     
     # Start JSON
@@ -392,6 +392,18 @@ main() {
     log_success "🎉 Sparkle upload completed!"
     log_info "Appcast URL: ${BUCKET_URL}/latest/darwin/appcast.xml"
     log_info "Downloads: ${BUCKET_URL}/latest/darwin/"
+    
+    # Verify CDN propagation with cache-busting
+    log_info "Verifying CDN propagation..."
+    sleep 2
+    local remote_version=$(curl -s -H "Cache-Control: no-cache" -H "Pragma: no-cache" "${BUCKET_URL}/latest/darwin/appcast.xml" | grep -o '<sparkle:shortVersionString>[^<]*</sparkle:shortVersionString>' | sed 's/<[^>]*>//g' || echo "unknown")
+    
+    if [ "$remote_version" = "$version" ]; then
+        log_success "CDN propagation verified - version $version is live"
+    else
+        log_warning "CDN propagation pending - remote shows $remote_version, expected $version"
+        log_info "This is normal and should resolve within a few minutes"
+    fi
 }
 
 # Run if executed directly


### PR DESCRIPTION
This pull request introduces improvements to the Sparkle updater integration for macOS, focusing on environment-specific configuration, enhanced logging, and build/deployment reliability. The changes ensure that the correct update feed URLs are used based on the environment, provide better diagnostics during initialization, and improve deployment scripts for cleaner builds and CDN propagation checks.

**Sparkle Updater Integration & Logging**
* Added detailed logging to Sparkle updater initialization in `_ClonesAppState` using `dart:developer`, including environment detection and appcast URL selection.
* Switched from `debugPrint` to structured logging for error handling in Sparkle initialization.
* Imported `dart:developer` to support enhanced logging.

**Environment-Specific Configuration**
* Updated `Info.plist` to use a variable `SUFeedURL` for the Sparkle feed, allowing dynamic update URLs per environment.
* Build script (`build_flutter_native.sh`) now sets the Sparkle feed URL based on the environment and exports it for use during the build. [[1]](diffhunk://#diff-d4c0ee2f87657fe5315f88c7fbef729f76a2e294dd95a01ad26c834163516d48R305-R318) [[2]](diffhunk://#diff-d4c0ee2f87657fe5315f88c7fbef729f76a2e294dd95a01ad26c834163516d48R339)
* Appcast generation script (`generate_appcast.sh`) now determines the download URL prefix based on environment and ensures fresh appcast generation.

**Deployment Reliability Enhancements**
* Deployment script (`deploy_macos.sh`) cleans previous build artifacts before starting a new build for a more reliable release process.
* Manifest creation in upload script now uses a more descriptive temporary file naming pattern for clarity. [[1]](diffhunk://#diff-d0b87e4d71568b1ba737ad862fe0c4e97cfd8e5e4179ab93eff12fecf0fd70f9L128-R128) [[2]](diffhunk://#diff-d0b87e4d71568b1ba737ad862fe0c4e97cfd8e5e4179ab93eff12fecf0fd70f9L209-R209)
* After uploading, the Sparkle upload script verifies CDN propagation by checking the live appcast version and logs the status, helping identify caching delays.

**Version Update**
* Bumped application version to `0.2.45+45` in `pubspec.yaml`.