### PR TITLE
Windows auto updater

### DIFF
--- a/LICENSE.rtf
+++ b/LICENSE.rtf
@@ -1,0 +1,12 @@
+{\rtf1\ansi\ansicpg1252\deff0\nouicompat{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
+{\*\generator Riched20 10.0.19041}\viewkind4\uc1
+\pard\sa200\sl276\slmult1\b\f0\fs28\lang9 MIT License\b0\fs22\par
+\par
+Copyright (c) 2025 clones-ai.com\par
+\par
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
+\par
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
+\par
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
+}

--- a/lib/infrastructure/windows_updater.dart
+++ b/lib/infrastructure/windows_updater.dart
@@ -2,7 +2,9 @@ import 'dart:developer' as developer;
 import 'dart:io';
 
 import 'package:auto_updater/auto_updater.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 class WindowsUpdater {
   WindowsUpdater._();
@@ -20,7 +22,7 @@ class WindowsUpdater {
 
     try {
       final appcastUrl = _getAppcastUrl(environment);
-      
+
       developer.log(
         '[WindowsUpdater] Initializing with appcast URL: $appcastUrl',
         name: 'WindowsUpdater',
@@ -50,9 +52,51 @@ class WindowsUpdater {
         '[WindowsUpdater] Checking for updates...',
         name: 'WindowsUpdater',
       );
-      
-      await autoUpdater.checkForUpdates();
-      
+
+      // Get current app version (without build number)
+      final packageInfo = await PackageInfo.fromPlatform();
+      final currentVersion = packageInfo.version; // e.g., "0.3.4"
+
+      developer.log(
+        '[WindowsUpdater] Current app version: $currentVersion (build: ${packageInfo.buildNumber})',
+        name: 'WindowsUpdater',
+      );
+
+      // Fetch and parse the appcast.xml to get the available version
+      const environment = String.fromEnvironment('ENVIRONMENT', defaultValue: 'dev');
+      final appcastUrl = _getAppcastUrl(environment);
+
+      final availableVersion = await _fetchAvailableVersion(appcastUrl);
+
+      if (availableVersion == null) {
+        developer.log(
+          '[WindowsUpdater] Could not determine available version from appcast',
+          name: 'WindowsUpdater',
+        );
+        return;
+      }
+
+      developer.log(
+        '[WindowsUpdater] Available version: $availableVersion',
+        name: 'WindowsUpdater',
+      );
+
+      // Compare versions (semantic only, ignore build number)
+      if (_isNewerVersion(availableVersion, currentVersion)) {
+        developer.log(
+          '[WindowsUpdater] New version available: $availableVersion > $currentVersion',
+          name: 'WindowsUpdater',
+        );
+
+        // Trigger the update check which will show the UI
+        await autoUpdater.checkForUpdates();
+      } else {
+        developer.log(
+          '[WindowsUpdater] No update needed: $availableVersion <= $currentVersion',
+          name: 'WindowsUpdater',
+        );
+      }
+
       developer.log(
         '[WindowsUpdater] Update check completed',
         name: 'WindowsUpdater',
@@ -64,6 +108,69 @@ class WindowsUpdater {
         level: 1000,
       );
     }
+  }
+
+  /// Fetches the available version from the appcast.xml
+  static Future<String?> _fetchAvailableVersion(String appcastUrl) async {
+    try {
+      final dio = Dio();
+      final response = await dio.get<String>(appcastUrl);
+
+      if (response.statusCode != 200 || response.data == null) {
+        return null;
+      }
+
+      // Parse the XML to extract sparkle:version or sparkle:shortVersionString
+      final xml = response.data!;
+
+      // Try to extract sparkle:version first
+      final versionMatch = RegExp(r'sparkle:version="([^"]+)"').firstMatch(xml);
+      if (versionMatch != null) {
+        return versionMatch.group(1);
+      }
+
+      // Fall back to sparkle:shortVersionString
+      final shortVersionMatch = RegExp(r'sparkle:shortVersionString="([^"]+)"').firstMatch(xml);
+      if (shortVersionMatch != null) {
+        return shortVersionMatch.group(1);
+      }
+
+      return null;
+    } catch (e) {
+      developer.log(
+        '[WindowsUpdater] Failed to fetch appcast: $e',
+        name: 'WindowsUpdater',
+        level: 1000,
+      );
+      return null;
+    }
+  }
+
+  /// Compares two semantic versions (ignoring build numbers)
+  /// Returns true if availableVersion > currentVersion
+  static bool _isNewerVersion(String availableVersion, String currentVersion) {
+    // Remove any build number suffix (e.g., "+114")
+    final availableClean = availableVersion.split('+').first;
+    final currentClean = currentVersion.split('+').first;
+
+    final availableParts = availableClean.split('.').map(int.tryParse).toList();
+    final currentParts = currentClean.split('.').map(int.tryParse).toList();
+
+    // Ensure both have 3 parts
+    while (availableParts.length < 3) availableParts.add(0);
+    while (currentParts.length < 3) currentParts.add(0);
+
+    // Compare major.minor.patch
+    for (int i = 0; i < 3; i++) {
+      final available = availableParts[i] ?? 0;
+      final current = currentParts[i] ?? 0;
+
+      if (available > current) return true;
+      if (available < current) return false;
+    }
+
+    // Versions are equal
+    return false;
   }
 
   static String _getAppcastUrl(String environment) {

--- a/lib/infrastructure/windows_updater.dart
+++ b/lib/infrastructure/windows_updater.dart
@@ -1,0 +1,76 @@
+import 'dart:developer' as developer;
+import 'dart:io';
+
+import 'package:auto_updater/auto_updater.dart';
+import 'package:flutter/foundation.dart';
+
+class WindowsUpdater {
+  WindowsUpdater._();
+
+  static Future<void> initialize({
+    required String environment,
+  }) async {
+    if (!Platform.isWindows || kIsWeb) {
+      developer.log(
+        'Windows updater only works on Windows',
+        name: 'WindowsUpdater',
+      );
+      return;
+    }
+
+    try {
+      final appcastUrl = _getAppcastUrl(environment);
+      
+      developer.log(
+        '[WindowsUpdater] Initializing with appcast URL: $appcastUrl',
+        name: 'WindowsUpdater',
+      );
+
+      await autoUpdater.setFeedURL(appcastUrl);
+      await autoUpdater.setScheduledCheckInterval(3600); // Check every hour
+
+      developer.log(
+        '[WindowsUpdater] Windows updater initialized successfully',
+        name: 'WindowsUpdater',
+      );
+    } catch (e) {
+      developer.log(
+        '[WindowsUpdater] Failed to initialize: $e',
+        name: 'WindowsUpdater',
+        level: 1000,
+      );
+    }
+  }
+
+  static Future<void> checkForUpdates() async {
+    if (!Platform.isWindows || kIsWeb) return;
+
+    try {
+      developer.log(
+        '[WindowsUpdater] Checking for updates...',
+        name: 'WindowsUpdater',
+      );
+      
+      await autoUpdater.checkForUpdates();
+      
+      developer.log(
+        '[WindowsUpdater] Update check completed',
+        name: 'WindowsUpdater',
+      );
+    } catch (e) {
+      developer.log(
+        '[WindowsUpdater] Failed to check for updates: $e',
+        name: 'WindowsUpdater',
+        level: 1000,
+      );
+    }
+  }
+
+  static String _getAppcastUrl(String environment) {
+    if (environment == 'prod') {
+      return 'https://releases.clones-ai.com/latest/windows/appcast.xml';
+    } else {
+      return 'https://releases-test.clones-ai.com/latest/windows/appcast.xml';
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:clones_desktop/application/deeplink_provider.dart';
 import 'package:clones_desktop/application/route_provider.dart';
 import 'package:clones_desktop/assets.dart';
 import 'package:clones_desktop/infrastructure/sparkle_updater.dart';
+import 'package:clones_desktop/infrastructure/windows_updater.dart';
 import 'package:clones_desktop/ui/main_layout.dart';
 import 'package:clones_desktop/ui/views/demo_detail/layouts/demo_detail_view.dart';
 import 'package:clones_desktop/ui/views/factory/layouts/factory_view.dart';
@@ -232,16 +233,26 @@ class _ClonesAppState extends ConsumerState<ClonesApp> {
   Future<void> _checkForUpdates() async {
     // Delay to ensure app is fully initialized
     await Future.delayed(const Duration(seconds: 2));
-    if (mounted) {
-      if (Platform.isMacOS) {
-        // Use native Sparkle updater on macOS for better performance and UX
-        await _initializeSparkleUpdater();
-      } else {
-        developer.log(
-          'Native updaters for Windows/Linux not yet implemented',
-          name: 'AppLifecycleManager',
-        );
-      }
+    if (!mounted) return;
+
+    const environment = String.fromEnvironment('ENVIRONMENT', defaultValue: 'dev');
+
+    if (Platform.isMacOS) {
+      // Use native Sparkle updater on macOS for better performance and UX
+      await _initializeSparkleUpdater();
+    } else if (Platform.isWindows) {
+      // Use auto_updater for Windows
+      developer.log(
+        '[WindowsUpdater] Initializing Windows updater...',
+        name: 'AppLifecycleManager',
+      );
+      await WindowsUpdater.initialize(environment: environment);
+      await WindowsUpdater.checkForUpdates();
+    } else {
+      developer.log(
+        'Native updaters for Linux not yet implemented',
+        name: 'AppLifecycleManager',
+      );
     }
   }
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import auto_updater_macos
 import media_kit_libs_macos_video
 import media_kit_video
 import package_info_plus
@@ -18,6 +19,7 @@ import wakelock_plus
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AutoUpdaterMacosPlugin.register(with: registry.registrar(forPlugin: "AutoUpdaterMacosPlugin"))
   MediaKitLibsMacosVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosVideoPlugin"))
   MediaKitVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitVideoPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  auto_updater:
+    dependency: "direct main"
+    description:
+      name: auto_updater
+      sha256: "74fd008b021d15e4fc50fb5f1923870e6374ae831bb1168241c23bc35a4e898b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  auto_updater_macos:
+    dependency: transitive
+    description:
+      name: auto_updater_macos
+      sha256: ef9de0daf38d782d2243fe131503a9404d62df762f5386e5360020e43c01867f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  auto_updater_platform_interface:
+    dependency: transitive
+    description:
+      name: auto_updater_platform_interface
+      sha256: ed5dff8cea18c58bc5ac787ff9122fedd1644272e02015d28c9b592f8078c5dc
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  auto_updater_windows:
+    dependency: transitive
+    description:
+      name: auto_updater_windows
+      sha256: "2bba20a71eee072f49b7267fedd5c4f1406c4b1b1e5b83932c634dbab75b80c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: clones_desktop
 description: "A desktop application for contributing to the world's largest dataset for multimodal computer-use agents."
 publish_to: 'none'
 
-version: 0.3.4+114
+version: 0.3.6+116
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
@@ -65,7 +65,7 @@ msix_config:
   publisher_display_name: Clones
   publisher: CN=ED6E50CB-2C1F-484F-B7E7-07431405E106
   identity_name: Clones.ClonesAIDesktop
-  msix_version: 0.3.4.114
+  msix_version: 0.3.6.116
   logo_path: assets/icons-app/icon.png
   start_menu_icon_path: assets/icons-app/icon.png
   tile_icon_path: assets/icons-app/icon.png

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: clones_desktop
 description: "A desktop application for contributing to the world's largest dataset for multimodal computer-use agents."
 publish_to: 'none'
 
-version: 0.3.3+113
+version: 0.3.4+114
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
@@ -11,6 +11,7 @@ environment:
 dependencies:
 
   auto_size_text: ^3.0.0
+  auto_updater: ^1.0.0
   cached_network_image: ^3.4.1
   collection: any
   crypto: any
@@ -64,7 +65,7 @@ msix_config:
   publisher_display_name: Clones
   publisher: CN=ED6E50CB-2C1F-484F-B7E7-07431405E106
   identity_name: Clones.ClonesAIDesktop
-  msix_version: 0.3.3.113
+  msix_version: 0.3.4.114
   logo_path: assets/icons-app/icon.png
   start_menu_icon_path: assets/icons-app/icon.png
   tile_icon_path: assets/icons-app/icon.png

--- a/scripts/windows/create_msi.ps1
+++ b/scripts/windows/create_msi.ps1
@@ -176,6 +176,7 @@ function New-WixFile {
     <!-- UI -->
     <UIRef Id='WixUI_InstallDir' />
     <Property Id='WIXUI_INSTALLDIR' Value='INSTALLFOLDER' />
+    <WixVariable Id='WixUILicenseRtf' Value='LICENSE.rtf' />
 
   </Product>
 </Wix>
@@ -230,6 +231,16 @@ function Invoke-Candle {
 
     Write-LogInfo "Compiling WiX files..."
 
+    # Copy LICENSE.rtf to output directory for WiX to find it
+    $licenseSource = "LICENSE.rtf"
+    if (Test-Path $licenseSource) {
+        $licenseDest = Join-Path $OutputDir "LICENSE.rtf"
+        Copy-Item $licenseSource $licenseDest -Force
+        Write-LogInfo "Copied LICENSE.rtf to build directory"
+    } else {
+        Write-LogWarning "LICENSE.rtf not found, installer will use default license text"
+    }
+
     $candleExe = Join-Path $WIX_BIN "candle.exe"
 
     $candleArgs = @(
@@ -267,6 +278,7 @@ function Invoke-Light {
     $lightArgs = @(
         "-out", $MsiPath,
         "-ext", "WixUIExtension",
+        "-b", $OutputDir,  # Add base path for finding LICENSE.rtf
         "-sw1076"  # Suppress ICE warning about sequence
     ) + $wixobjFiles
 

--- a/scripts/windows/deploy_windows.bat
+++ b/scripts/windows/deploy_windows.bat
@@ -25,7 +25,7 @@ if errorlevel 1 (
 
 echo ✅ Build completed successfully!
 
-echo ℹ️ Step 2/3: Generating manifests...
+echo ℹ️ Step 2/3: Generating manifests and appcast...
 powershell -ExecutionPolicy Bypass -File "scripts\windows\generate_manifest_windows.ps1" -Environment "%ENVIRONMENT%"
 
 if errorlevel 1 (
@@ -33,7 +33,7 @@ if errorlevel 1 (
     exit /b 1
 )
 
-echo ✅ Manifests generated successfully!
+echo ✅ Manifests and appcast generated successfully!
 
 echo ℹ️ Step 3/3: Uploading to Tigris (%ENVIRONMENT%^)...
 call scripts\windows\upload_windows.bat "%ENVIRONMENT%"
@@ -50,9 +50,11 @@ echo ℹ️ Your app is now available:
 if "%ENVIRONMENT%"=="prod" (
     echo   📱 Downloads: https://releases.clones-ai.com/latest/windows/
     echo   🔗 Version manifest: https://releases.clones-ai.com/latest/windows/version.json
+    echo   🔄 Auto-updater feed: https://releases.clones-ai.com/latest/windows/appcast.xml
 ) else if "%ENVIRONMENT%"=="test" (
     echo   📱 Downloads: https://releases-test.clones-ai.com/latest/windows/
     echo   🔗 Version manifest: https://releases-test.clones-ai.com/latest/windows/version.json
+    echo   🔄 Auto-updater feed: https://releases-test.clones-ai.com/latest/windows/appcast.xml
 ) else (
     echo   🌐 Unknown environment: %ENVIRONMENT%
 )

--- a/scripts/windows/deploy_windows.ps1
+++ b/scripts/windows/deploy_windows.ps1
@@ -32,7 +32,7 @@ function Main {
     Write-Info "      Otherwise, only ZIP package will be available"
     Write-Host ""
 
-    Write-Info "Step 1/4: Building release..."
+    Write-Info "Step 1/5: Building release..."
 
     # Execute build script
     try {
@@ -54,7 +54,7 @@ function Main {
 
     Write-Success "Build completed successfully!"
 
-    Write-Info "Step 2/4: Building Windows Store package..."
+    Write-Info "Step 2/5: Building Windows Store package..."
 
     # Execute Store build script
     try {
@@ -73,7 +73,7 @@ function Main {
         Write-Warning "Store package build script execution failed: $_"
     }
 
-    Write-Info "Step 3/4: Generating manifests..."
+    Write-Info "Step 3/5: Generating manifests..."
 
     # Execute manifest generation script
     try {
@@ -94,7 +94,28 @@ function Main {
 
     Write-Success "Manifests generated successfully!"
 
-    Write-Info "Step 4/4: Uploading to Tigris ($Environment)..."
+    Write-Info "Step 4/5: Generating appcast..."
+
+    # Execute appcast generation script
+    try {
+        if ($Verbose) {
+            & "scripts\windows\generate_appcast_windows.ps1" -Environment $Environment -VerboseLogging
+        } else {
+            & "scripts\windows\generate_appcast_windows.ps1" -Environment $Environment
+        }
+
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Appcast generation failed, aborting deployment"
+            exit 1
+        }
+    } catch {
+        Write-Error "Appcast generation script execution failed: $_"
+        exit 1
+    }
+
+    Write-Success "Appcast generated successfully!"
+
+    Write-Info "Step 5/5: Uploading to Tigris ($Environment)..."
 
     # Execute upload script
     try {

--- a/scripts/windows/generate_appcast_windows.ps1
+++ b/scripts/windows/generate_appcast_windows.ps1
@@ -112,8 +112,7 @@ function New-AppcastXML {
     )
 
     $pubDate = [DateTime]::UtcNow.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'")
-    $releaseNotesUrl = "$BaseUrl/release-notes/$Version.html"
-    
+
     # Prefer MSI installer, fallback to EXE, then ZIP
     $downloadUrl = ""
     $fileSize = 0
@@ -152,9 +151,8 @@ function New-AppcastXML {
     <language>en</language>
     <item>
       <title>Version $Version</title>
-      <sparkle:releaseNotesLink>$releaseNotesUrl</sparkle:releaseNotesLink>
       <pubDate>$pubDate</pubDate>
-      <enclosure 
+      <enclosure
         url="$downloadUrl"
         sparkle:version="$Version"
         sparkle:shortVersionString="$Version"

--- a/scripts/windows/generate_appcast_windows.ps1
+++ b/scripts/windows/generate_appcast_windows.ps1
@@ -1,0 +1,212 @@
+# Clones Desktop - Windows Appcast Generation Script
+# Generates Sparkle-compatible appcast.xml for Windows auto_updater
+
+param(
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("dev", "test", "prod")]
+    [string]$Environment,
+    [switch]$VerboseLogging
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Generating Windows Appcast for $Environment" -ForegroundColor Cyan
+
+$ROOT_DIR = Get-Location
+
+# Colored output functions
+function Write-LogInfo($Message) {
+    Write-Host "$Message" -ForegroundColor Blue
+}
+
+function Write-LogSuccess($Message) {
+    Write-Host "$Message" -ForegroundColor Green
+}
+
+function Write-LogWarning($Message) {
+    Write-Host "$Message" -ForegroundColor Yellow
+}
+
+function Write-LogError($Message) {
+    Write-Host "$Message" -ForegroundColor Red
+}
+
+# Get app version from pubspec.yaml
+function Get-AppVersion {
+    if (-not (Test-Path "pubspec.yaml")) {
+        Write-LogError "pubspec.yaml not found"
+        exit 1
+    }
+
+    try {
+        $content = Get-Content "pubspec.yaml" -Raw
+
+        if ($content -match 'version:\s*([^+\s]+)') {
+            $version = $matches[1]
+
+            if (-not $version) {
+                Write-LogError "Could not extract version from pubspec.yaml"
+                exit 1
+            }
+
+            return $version
+        } else {
+            Write-LogError "Could not find version in pubspec.yaml"
+            exit 1
+        }
+    } catch {
+        Write-LogError "Failed to parse pubspec.yaml: $_"
+        exit 1
+    }
+}
+
+# Read version.json manifest
+function Get-VersionManifest {
+    param([string]$Environment)
+    
+    $manifestPath = "releases\$Environment\windows\version.json"
+    
+    if (-not (Test-Path $manifestPath)) {
+        Write-LogError "Version manifest not found: $manifestPath"
+        Write-LogError "Please run generate_manifest_windows.ps1 first"
+        exit 1
+    }
+
+    try {
+        $manifestContent = Get-Content $manifestPath -Raw | ConvertFrom-Json
+        return $manifestContent
+    } catch {
+        Write-LogError "Failed to parse version manifest: $_"
+        exit 1
+    }
+}
+
+# Get base URL for environment
+function Get-BaseUrl {
+    param([string]$Environment)
+    
+    switch ($Environment) {
+        "prod" {
+            return "https://releases.clones-ai.com"
+        }
+        "test" {
+            return "https://releases-test.clones-ai.com"
+        }
+        "dev" {
+            return "https://releases-test.clones-ai.com"
+        }
+        default {
+            Write-LogError "Invalid environment: $Environment"
+            exit 1
+        }
+    }
+}
+
+# Generate Sparkle appcast.xml
+function New-AppcastXML {
+    param(
+        [string]$Version,
+        [object]$VersionManifest,
+        [string]$BaseUrl,
+        [string]$Environment
+    )
+
+    $pubDate = [DateTime]::UtcNow.ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'")
+    $releaseNotesUrl = "$BaseUrl/release-notes/$Version.html"
+    
+    # Prefer MSI installer, fallback to EXE, then ZIP
+    $downloadUrl = ""
+    $fileSize = 0
+    $fileName = ""
+    
+    if ($VersionManifest.files.PSObject.Properties["windows_x64_msi"]) {
+        $file = $VersionManifest.files.windows_x64_msi
+        $downloadUrl = $file.url -replace '\{\{BASE_URL\}\}', $BaseUrl
+        $fileSize = $file.size
+        $fileName = $file.filename
+        Write-LogInfo "Using MSI installer for appcast: $fileName"
+    } elseif ($VersionManifest.files.PSObject.Properties["windows_x64_exe"]) {
+        $file = $VersionManifest.files.windows_x64_exe
+        $downloadUrl = $file.url -replace '\{\{BASE_URL\}\}', $BaseUrl
+        $fileSize = $file.size
+        $fileName = $file.filename
+        Write-LogInfo "Using NSIS installer for appcast: $fileName"
+    } elseif ($VersionManifest.files.PSObject.Properties["windows_x64_zip"]) {
+        $file = $VersionManifest.files.windows_x64_zip
+        $downloadUrl = $file.url -replace '\{\{BASE_URL\}\}', $BaseUrl
+        $fileSize = $file.size
+        $fileName = $file.filename
+        Write-LogInfo "Using ZIP archive for appcast: $fileName"
+    } else {
+        Write-LogError "No suitable Windows files found in version manifest"
+        exit 1
+    }
+
+    $appcastXml = @"
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Clones Desktop</title>
+    <link>$BaseUrl/latest/windows/appcast.xml</link>
+    <description>Clones Desktop update feed</description>
+    <language>en</language>
+    <item>
+      <title>Version $Version</title>
+      <sparkle:releaseNotesLink>$releaseNotesUrl</sparkle:releaseNotesLink>
+      <pubDate>$pubDate</pubDate>
+      <enclosure 
+        url="$downloadUrl"
+        sparkle:version="$Version"
+        sparkle:shortVersionString="$Version"
+        length="$fileSize"
+        type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>
+"@
+
+    return $appcastXml
+}
+
+# Main execution
+function Main {
+    Write-LogInfo "Starting appcast generation for environment: $Environment"
+
+    # Get version and base URL
+    $version = Get-AppVersion
+    $baseUrl = Get-BaseUrl -Environment $Environment
+    Write-LogInfo "App version: $version"
+    Write-LogInfo "Base URL: $baseUrl"
+
+    # Read version manifest
+    $versionManifest = Get-VersionManifest -Environment $Environment
+
+    # Generate appcast XML
+    $appcastXml = New-AppcastXML -Version $version -VersionManifest $versionManifest -BaseUrl $baseUrl -Environment $Environment
+
+    # Save appcast.xml
+    $releaseDir = "releases\$Environment\windows"
+    $appcastPath = "$releaseDir\appcast.xml"
+    
+    $appcastXml | Set-Content -Path $appcastPath -Encoding UTF8
+
+    Write-LogSuccess "Appcast XML generated: $appcastPath"
+    
+    if ($VerboseLogging) {
+        Write-LogInfo "Appcast content:"
+        Write-Host $appcastXml -ForegroundColor Gray
+    }
+
+    Write-Host ""
+    Write-LogSuccess "Appcast generation completed!"
+    Write-LogInfo "Appcast file: $appcastPath"
+    Write-LogInfo "Feed URL: $baseUrl/latest/windows/appcast.xml"
+}
+
+# Run main
+try {
+    Main
+} catch {
+    Write-LogError "Appcast generation failed: $_"
+    exit 1
+}

--- a/scripts/windows/generate_manifest_windows.ps1
+++ b/scripts/windows/generate_manifest_windows.ps1
@@ -429,6 +429,16 @@ function Main {
     Write-LogInfo "Generating manifests..."
     $versionManifest = New-VersionManifest -Version $version -Archives $archives -ReleaseDir $releaseDir
     $tauriManifest = New-TauriManifest -Version $version -Archives $archives -ReleaseDir $releaseDir
+    
+    # Generate Windows appcast for auto_updater
+    Write-LogInfo "Generating Windows appcast..."
+    try {
+        & "$PSScriptRoot\generate_appcast_windows.ps1" -Environment $Environment
+        Write-LogSuccess "Windows appcast generated successfully"
+    } catch {
+        Write-LogWarning "Failed to generate appcast: $_"
+        Write-LogWarning "Continuing without appcast.xml"
+    }
 
     Write-Host ""
     Write-LogSuccess "Manifest generation completed!"

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <auto_updater_windows/auto_updater_windows_plugin_c_api.h>
 #include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
 #include <media_kit_video/media_kit_video_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
@@ -14,6 +15,8 @@
 #include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AutoUpdaterWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AutoUpdaterWindowsPluginCApi"));
   MediaKitLibsWindowsVideoPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("MediaKitLibsWindowsVideoPluginCApi"));
   MediaKitVideoPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  auto_updater_windows
   media_kit_libs_windows_video
   media_kit_video
   screen_retriever_windows


### PR DESCRIPTION
This pull request introduces a Windows auto-update feature for the desktop application, including support for the auto_updater package and the necessary infrastructure for update checks and installer licensing. It also updates deployment scripts to generate and reference an appcast feed, and ensures the installer displays the correct license text. The application version is incremented as part of the release.

**Windows Auto-Update Feature:**

* Added new `WindowsUpdater` class in `lib/infrastructure/windows_updater.dart` using the `auto_updater` package to check for updates and trigger UI prompts for Windows users.
* Integrated `WindowsUpdater` into the app lifecycle in `lib/main.dart`, so the updater is initialized and checks for updates on Windows startup. [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R10) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L235-L246)
* Added `auto_updater` dependency to `pubspec.yaml`.

**Installer and Licensing Improvements:**

* Added `LICENSE.rtf` file and updated Windows installer scripts to include and reference this license for display during installation. [[1]](diffhunk://#diff-e6734e0bba6c97e2f53561537ecea4b6b4320f81b44bf0fcc638fec4add7e7afR1-R12) [[2]](diffhunk://#diff-5b9fc1f14f668e7513c9ab0456e407d5a01a82ce9750a91310306e86bc76340eR179) [[3]](diffhunk://#diff-5b9fc1f14f668e7513c9ab0456e407d5a01a82ce9750a91310306e86bc76340eR234-R243) [[4]](diffhunk://#diff-5b9fc1f14f668e7513c9ab0456e407d5a01a82ce9750a91310306e86bc76340eR281)

**Deployment and Appcast Feed:**

* Updated deployment scripts (`deploy_windows.bat`, `deploy_windows.ps1`) to generate and reference the appcast XML feed required for auto-updates, and improved status messaging for manifests and appcast generation. [[1]](diffhunk://#diff-8cea5950ac235357168c19f2b7764c6cf5c8b808dd499acef742cfeb7fa8623dL28-R36) [[2]](diffhunk://#diff-8cea5950ac235357168c19f2b7764c6cf5c8b808dd499acef742cfeb7fa8623dR53-R57) [[3]](diffhunk://#diff-ad7ceaebb5445b24d78f193157625f46dd4db09d750fde6c30e114799ded5b72L35-R35) [[4]](diffhunk://#diff-ad7ceaebb5445b24d78f193157625f46dd4db09d750fde6c30e114799ded5b72L57-R57) [[5]](diffhunk://#diff-ad7ceaebb5445b24d78f193157625f46dd4db09d750fde6c30e114799ded5b72L76-R76) [[6]](diffhunk://#diff-ad7ceaebb5445b24d78f193157625f46dd4db09d750fde6c30e114799ded5b72L97-R118)

**Version Bump:**

* Incremented application and installer version to `0.3.6+116` in `pubspec.yaml` and MSI config. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L5-R5) [[2]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L67-R68)

**Plugin Registration (macOS):**

* Registered `auto_updater_macos` plugin in `macos/Flutter/GeneratedPluginRegistrant.swift` to ensure compatibility and plugin registration for macOS builds. [[1]](diffhunk://#diff-e0a0e103075365af1fb906fa24889fc5ed61c2020ef2efeb23fe020123abc325R8) [[2]](diffhunk://#diff-e0a0e103075365af1fb906fa24889fc5ed61c2020ef2efeb23fe020123abc325R22)